### PR TITLE
Fixing the load balancer example.

### DIFF
--- a/support/examples-and-tutorials/load-balancer.html
+++ b/support/examples-and-tutorials/load-balancer.html
@@ -18,9 +18,9 @@
 <ol>
   <li>Create the <code>cmd_lines</code> file in the directory you created.
 
-    <pre><code>$ for  i in {1..100} ; do
-> echo "sleep 2; echo hostname $i" >> cmd_lines
-> done</code></pre>
+    <pre><code>$ for  i in {1..100} ; do \
+ echo "sleep 2; echo process $i" >> cmd_lines ; \
+ done</code></pre>
   </li>
 
   <li>Load the load balancer module.
@@ -30,6 +30,7 @@
 
   <li>Submit your job, for example using srun.
 
-    <pre><code>$ srun lb cmd_lines</code></pre>
+    <pre><code>$ module load slurm</code></pre>
+    <pre><code>$ srun -N 1 --ntasks-per-node=12 lb cmd_lines</code></pre>
   </li>
 </ol>

--- a/support/examples-and-tutorials/parallel-mpi-jobs.html
+++ b/support/examples-and-tutorials/parallel-mpi-jobs.html
@@ -95,3 +95,37 @@ srun --mpi=pmi2 mpi_test</code></pre>
 <p>More information is available in
   the <a href="http://www.schedmd.com/slurmdocs/srun.html"><code>srun</code>
   manpage</a>, under the heading "MULTIPLE PROGRAM CONFIGURATION."</p>
+
+<h2>Custom task geometry</h2>
+<p>
+If your MPI program requires a custom task geometry you will need to redefine
+the environment variable <code>SLURM_TASKS_PER_NODE</code> and use
+<code>mpiexec</code> to execute you program.
+</p>
+<p>
+In this case we request 4 nodes with 12 tasks per node giving a total of
+48 tasks. However we want the root rank (<code>rank 0</code>) to run on
+the first node by itself, then the next two nodes to run 12 tasks each
+(<code>ranks 1-12</code>) and last node to run 6 tasks only
+(<code>ranks 13-18</code>).
+</p>
+<pre>
+<code>
+#!/bin/bash
+
+#SBATCH --job-name mpi_test
+#SBATCH --qos janus
+#SBATCH --nodes 4
+#SBATCH --ntasks-per-node 12
+#SBATCH --time 00:10:00
+#SBATCH --output mpi_test.out
+
+# the slurm module provides the srun command
+module load slurm
+
+module load intel/impi-13.0.0
+
+export SLURM_TASKS_PER_NODE='1,12(x2),6'
+mpiexec ./mpi_test
+</code>
+</pre>


### PR DESCRIPTION
This should address #79. On the module side I have made the Intel & IMPI module the default (which do load those modules). 